### PR TITLE
[Refactor] 세션스토리지 로직 보완

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
 	implementation "ch.qos.logback:logback-classic:1.4.14"
-	implementation 'org.thymeleaf:thymeleaf:3.1.1.RELEASE'
+	implementation "org.thymeleaf:thymeleaf:3.1.1.RELEASE"
 
 	testImplementation "org.mockito:mockito-core:5.4.0"
 	testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"

--- a/build.gradle
+++ b/build.gradle
@@ -21,7 +21,7 @@ repositories {
 
 dependencies {
 	implementation "ch.qos.logback:logback-classic:1.4.14"
-	implementation "org.thymeleaf:thymeleaf:3.1.1.RELEASE"
+	implementation 'org.thymeleaf:thymeleaf:3.1.1.RELEASE'
 
 	testImplementation "org.mockito:mockito-core:5.4.0"
 	testImplementation "org.junit.jupiter:junit-jupiter-api:5.10.0"

--- a/src/main/java/com/youlpring/YoulpringApplication.java
+++ b/src/main/java/com/youlpring/YoulpringApplication.java
@@ -1,6 +1,7 @@
 package com.youlpring;
 
 
+import com.youlpring.common.core.DefaultInitializer;
 import com.youlpring.tomcat.apache.catalina.connector.Connector;
 import com.youlpring.tomcat.apache.catalina.startup.Tomcat;
 
@@ -9,6 +10,7 @@ public class YoulpringApplication {
     public static void main(String[] args) {
         Connector connector = new Connector();
         final Tomcat tomcat = new Tomcat();
-        tomcat.start(connector);
+        DefaultInitializer defaultInitializer = new DefaultInitializer();
+        tomcat.start(connector, defaultInitializer);
     }
 }

--- a/src/main/java/com/youlpring/common/core/DefaultInitializer.java
+++ b/src/main/java/com/youlpring/common/core/DefaultInitializer.java
@@ -1,0 +1,19 @@
+package com.youlpring.common.core;
+
+import com.youlpring.jws.common.config.SessionConfiguration;
+import com.youlpring.tomcat.apache.coyote.http11.context.SessionGarbageCollector;
+
+import java.util.concurrent.TimeUnit;
+
+public class DefaultInitializer implements Initializer {
+
+    public void init() {
+        sessionInit();
+    }
+
+    private void sessionInit() {
+        SessionGarbageCollector sessionGarbageCollector = new SessionGarbageCollector(
+                60 * SessionConfiguration.SESSION_MAX_EFFECTIVE_MINUTES, 60, TimeUnit.SECONDS);
+        sessionGarbageCollector.processExpiredSessions();
+    }
+}

--- a/src/main/java/com/youlpring/common/core/Initializer.java
+++ b/src/main/java/com/youlpring/common/core/Initializer.java
@@ -1,0 +1,5 @@
+package com.youlpring.common.core;
+
+public interface Initializer {
+    void init();
+}

--- a/src/main/java/com/youlpring/jws/common/config/SessionConfiguration.java
+++ b/src/main/java/com/youlpring/jws/common/config/SessionConfiguration.java
@@ -2,5 +2,5 @@ package com.youlpring.jws.common.config;
 
 public class SessionConfiguration {
 
-    public final static Long SESSION_MAX_EFFECTIVE_MINUTES = 10L;
+    public final static Long SESSION_MAX_EFFECTIVE_MINUTES = 30L;
 }

--- a/src/main/java/com/youlpring/jws/controller/RequestHandlerMapping.java
+++ b/src/main/java/com/youlpring/jws/controller/RequestHandlerMapping.java
@@ -2,8 +2,10 @@ package com.youlpring.jws.controller;
 
 import com.youlpring.jws.controller.User.UserController;
 import com.youlpring.jws.controller.User.UserRegisterController;
+import com.youlpring.jws.controller.home.HomeController;
 import com.youlpring.jws.controller.login.LogoutController;
 import com.youlpring.jws.controller.login.LoginController;
+import com.youlpring.jws.controller.login.SessionReloadController;
 
 import java.util.HashMap;
 import java.util.Map;
@@ -26,6 +28,7 @@ public class RequestHandlerMapping {
         controllerMap.put("/logout", LogoutController.INSTANCE);
         controllerMap.put("/user", UserController.INSTANCE);
         controllerMap.put("/register", UserRegisterController.INSTANCE);
+        controllerMap.put("/session/reload", SessionReloadController.INSTANCE);
     }
 
     public static Controller getController(String url) {

--- a/src/main/java/com/youlpring/jws/controller/home/HomeController.java
+++ b/src/main/java/com/youlpring/jws/controller/home/HomeController.java
@@ -1,5 +1,6 @@
-package com.youlpring.jws.controller;
+package com.youlpring.jws.controller.home;
 
+import com.youlpring.jws.controller.AbstractController;
 import com.youlpring.tomcat.apache.coyote.http11.request.HttpRequest;
 import com.youlpring.tomcat.apache.coyote.http11.response.HttpResponse;
 

--- a/src/main/java/com/youlpring/jws/controller/login/SessionReloadController.java
+++ b/src/main/java/com/youlpring/jws/controller/login/SessionReloadController.java
@@ -1,0 +1,20 @@
+package com.youlpring.jws.controller.login;
+
+import com.youlpring.jws.controller.AbstractController;
+import com.youlpring.tomcat.apache.coyote.http11.context.SessionManager;
+import com.youlpring.tomcat.apache.coyote.http11.request.HttpRequest;
+import com.youlpring.tomcat.apache.coyote.http11.response.HttpResponse;
+
+public class SessionReloadController extends AbstractController {
+
+    public static final SessionReloadController INSTANCE = new SessionReloadController();
+
+    private static final SessionManager sessionManager = SessionManager.INSTANCE;
+
+    private SessionReloadController() {}
+
+    @Override
+    public void doGet(HttpRequest request, HttpResponse response) {
+        response.createSessionCookie(sessionManager.sessionRefresh(request.getSession()).getSessionKey());
+    }
+}

--- a/src/main/java/com/youlpring/tomcat/apache/catalina/startup/Tomcat.java
+++ b/src/main/java/com/youlpring/tomcat/apache/catalina/startup/Tomcat.java
@@ -1,5 +1,6 @@
 package com.youlpring.tomcat.apache.catalina.startup;
 
+import com.youlpring.common.core.Initializer;
 import com.youlpring.tomcat.apache.catalina.connector.Connector;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -10,8 +11,9 @@ public class Tomcat {
 
     private static final Logger log = LoggerFactory.getLogger(Tomcat.class);
 
-    public void start(Connector connector) {
+    public void start(Connector connector, Initializer initializer) {
         connector.start();
+        initializer.init();
         try {
             System.in.read();
         } catch (IOException e) {

--- a/src/main/java/com/youlpring/tomcat/apache/coyote/http11/context/Session.java
+++ b/src/main/java/com/youlpring/tomcat/apache/coyote/http11/context/Session.java
@@ -10,10 +10,10 @@ public class Session {
     private final LocalDateTime maxEffectiveTime;
     private final UserSessionInfo userInfo;
 
-    public Session(String sessionKey, UserSessionInfo userInfo) {
+    public Session(String sessionKey, UserSessionInfo userInfo, LocalDateTime maxEffectiveTime) {
         this.sessionKey = sessionKey;
         this.userInfo = userInfo;
-        this.maxEffectiveTime = LocalDateTime.now().plusMinutes(SessionConfiguration.SESSION_MAX_EFFECTIVE_MINUTES);
+        this.maxEffectiveTime = maxEffectiveTime;
     }
 
     public String getSessionKey() {

--- a/src/main/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionGarbageCollector.java
+++ b/src/main/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionGarbageCollector.java
@@ -13,7 +13,7 @@ public class SessionGarbageCollector {
 
     private final TimeUnit timeUnit;
 
-    SessionManager sessionManager = SessionManager.INSTANCE;
+    private final SessionManager sessionManager = SessionManager.INSTANCE;
 
     public SessionGarbageCollector(long initialDelay, long period, TimeUnit timeUnit) {
         this.initialDelay = initialDelay;

--- a/src/main/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionGarbageCollector.java
+++ b/src/main/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionGarbageCollector.java
@@ -1,0 +1,36 @@
+package com.youlpring.tomcat.apache.coyote.http11.context;
+
+import java.util.List;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+
+public class SessionGarbageCollector {
+
+    private final long initialDelay;
+
+    private final long period;
+
+    private final TimeUnit timeUnit;
+
+    SessionManager sessionManager = SessionManager.INSTANCE;
+
+    public SessionGarbageCollector(long initialDelay, long period, TimeUnit timeUnit) {
+        this.initialDelay = initialDelay;
+        this.period = period;
+        this.timeUnit = timeUnit;
+    }
+
+    public void processExpiredSessions() {
+        List<String> sessionKeys = sessionManager.getSessionKeys();
+        ScheduledExecutorService scheduler = Executors.newScheduledThreadPool(1);
+        Runnable task = () -> {
+            for (String key : sessionKeys) {
+                Session session = sessionManager.findSession(key);
+                if (session == null) continue;
+                sessionManager.isTimeOver(session);
+            }
+        };
+        scheduler.scheduleAtFixedRate(task, initialDelay, period, timeUnit);
+    }
+}

--- a/src/main/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionManager.java
+++ b/src/main/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionManager.java
@@ -83,4 +83,11 @@ public class SessionManager implements Manager {
     public List<String> getSessionKeys() {
         return new ArrayList<>(sessionStorage.keySet());
     }
+
+    public Session sessionRefresh(Session oldSession) {
+        Session newSession = createSession(oldSession.getUserInfo());
+        remove(oldSession);
+        add(newSession);
+        return newSession;
+    }
 }

--- a/src/main/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionManager.java
+++ b/src/main/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionManager.java
@@ -1,6 +1,7 @@
 package com.youlpring.tomcat.apache.coyote.http11.context;
 
 import com.youlpring.jws.common.codeAndMessage.ErrorCodeAndMessage;
+import com.youlpring.jws.common.config.SessionConfiguration;
 import com.youlpring.jws.common.exception.LoginException;
 import com.youlpring.tomcat.apache.catalina.Manager;
 import com.youlpring.tomcat.apache.coyote.http11.request.HttpRequest;
@@ -8,6 +9,8 @@ import com.youlpring.tomcat.apache.coyote.http11.response.HttpResponse;
 
 import java.security.SecureRandom;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 
@@ -55,7 +58,8 @@ public class SessionManager implements Manager {
         if (userSessionInfo == null) {
             throw new LoginException(ErrorCodeAndMessage.FAILED_LOGIN);
         }
-        return new Session(createSessionId(), userSessionInfo);
+        return new Session(createSessionId(), userSessionInfo,
+                LocalDateTime.now().plusMinutes(SessionConfiguration.SESSION_MAX_EFFECTIVE_MINUTES));
     }
 
     public boolean isTimeOver(Session session) {
@@ -74,5 +78,9 @@ public class SessionManager implements Manager {
             buffer.append(SESSION_RANDOM_STRING.charAt(random.nextInt(SESSION_RANDOM_STRING.length())));
         }
         return buffer.toString();
+    }
+
+    public List<String> getSessionKeys() {
+        return new ArrayList<>(sessionStorage.keySet());
     }
 }

--- a/src/main/java/com/youlpring/tomcat/apache/coyote/http11/response/HttpResponse.java
+++ b/src/main/java/com/youlpring/tomcat/apache/coyote/http11/response/HttpResponse.java
@@ -94,6 +94,10 @@ public class HttpResponse {
         return responseBody;
     }
 
+    public Cookie getCookie(String key) {
+        return responseHeader.getCookie(key);
+    }
+
     public byte[] getHttpByte() {
         StringBuilder builder = new StringBuilder();
         builder.append(this.getFirstHeader()).append("\r\n");

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -28,6 +28,22 @@
                     });
                 });
             });
+            $(document).ready(function () {
+                $('#reload').click(function (e) {
+                    e.preventDefault();
+                    $.ajax({
+                        type: 'GET',
+                        url: 'session/reload',
+                        data: $(this).serialize(),
+                        success: function (data) {
+                            alert('초기화 되었습니다.');
+                        },
+                        error: function (xhr, status, error) {
+                            alert('초기화 실패!');
+                        }
+                    });
+                });
+            });
         </script>
     </head>
     <body class="sb-nav-fixed">
@@ -37,31 +53,16 @@
             <!-- Sidebar Toggle-->
             <button class="btn btn-link btn-sm order-1 order-lg-0 me-4 me-lg-0" id="sidebarToggle" href="#!"><i class="fas fa-bars"></i></button>
 
-            <!-- before login -->
             <div class="navbar-nav d-none d-md-inline-block ms-auto me-0 me-md-3 my-2 my-md-0">
-                <div th:if="${isLogin}">
-                    <a class="nav-link" id="logout" role="button"><i class="fas fa-user fa-fw"></i>&nbsp;로그아웃</a>
+                <div th:if="${isLogin}" style="display: flex">
+                    <a class="nav-link" id="reload" role="button"><i class="fas fa-sync-alt fa-fw"></i>&nbsp;시간 연장</a>
+                    <a class="nav-link" href="user" role="button"><i class="fas fa-user fa-fw"></i>&nbsp;내 정보</a>
+                    <a class="nav-link" id="logout" role="button"><i class="fas fa-sign-out-alt fa-fw"></i>&nbsp;로그아웃</a>
                 </div>
-                <div th:unless="${isLogin}">
-                    <a class="nav-link" href="login" role="button"><i class="fas fa-user fa-fw"></i>&nbsp;로그인</a>
+                <div th:unless="${isLogin}" style="display: flex">
+                    <a class="nav-link" href="login" role="button"><i class="fas fa-sign-in-alt fa-fw"></i>&nbsp;로그인</a>
                 </div>
-
             </div>
-            <!-- before login -->
-
-            <!-- after login -->
-<!--            <ul class="navbar-nav ms-auto ms-md-0 me-3 me-lg-4">-->
-<!--                <li class="nav-item dropdown">-->
-<!--                    <a class="nav-link dropdown-toggle" id="navbarDropdown" href="#" role="button" data-bs-toggle="dropdown" aria-expanded="false"><i class="fas fa-user fa-fw"></i></a>-->
-<!--                    <ul class="dropdown-menu dropdown-menu-end" aria-labelledby="navbarDropdown">-->
-<!--                        <li><a class="dropdown-item" href="#!">Settings</a></li>-->
-<!--                        <li><hr class="dropdown-divider" /></li>-->
-<!--                        <li><a class="dropdown-item" href="#!">Logout</a></li>-->
-<!--                    </ul>-->
-<!--                </li>-->
-<!--            </ul>-->
-            <!-- after login -->
-
         </nav>
         <div id="layoutSidenav">
             <div id="layoutSidenav_nav">

--- a/src/test/java/com/youlpring/Fixture/tomcat/coyote/http11/UserSessionInfoFixture.java
+++ b/src/test/java/com/youlpring/Fixture/tomcat/coyote/http11/UserSessionInfoFixture.java
@@ -1,0 +1,13 @@
+package com.youlpring.Fixture.tomcat.coyote.http11;
+
+import com.youlpring.tomcat.apache.coyote.http11.context.UserSessionInfo;
+
+public class UserSessionInfoFixture {
+
+    public static final String ACCOUNT = "test";
+
+    public static final String EMAIL = "test@gmail.com";
+
+    public static final UserSessionInfo USER_SESSION_INFO = new UserSessionInfo(1L, ACCOUNT, EMAIL);
+
+}

--- a/src/test/java/com/youlpring/jws/controller/HomeControllerTest.java
+++ b/src/test/java/com/youlpring/jws/controller/HomeControllerTest.java
@@ -1,5 +1,6 @@
 package com.youlpring.jws.controller;
 
+import com.youlpring.jws.controller.home.HomeController;
 import com.youlpring.tomcat.apache.coyote.http11.request.HttpRequest;
 import com.youlpring.tomcat.apache.coyote.http11.response.HttpResponse;
 import org.junit.jupiter.api.DisplayName;

--- a/src/test/java/com/youlpring/jws/controller/RequestHandlerMappingTest.java
+++ b/src/test/java/com/youlpring/jws/controller/RequestHandlerMappingTest.java
@@ -2,6 +2,7 @@ package com.youlpring.jws.controller;
 
 import com.youlpring.jws.controller.User.UserController;
 import com.youlpring.jws.controller.User.UserRegisterController;
+import com.youlpring.jws.controller.home.HomeController;
 import com.youlpring.jws.controller.login.LoginController;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/src/test/java/com/youlpring/jws/controller/User/UserControllerTest.java
+++ b/src/test/java/com/youlpring/jws/controller/User/UserControllerTest.java
@@ -12,6 +12,8 @@ import com.youlpring.tomcat.apache.coyote.http11.response.HttpResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
+import java.time.LocalDateTime;
+
 import static com.youlpring.Fixture.jws.user.UserFixture.ACCOUNT;
 import static com.youlpring.Fixture.jws.user.UserFixture.PASSWORD;
 import static com.youlpring.Fixture.tomcat.coyote.http11.RequestFixture.EMAIL_KEY;
@@ -32,9 +34,12 @@ class UserControllerTest extends InitDbBase {
 
         HttpRequest mockRequest = mock(HttpRequest.class);
         HttpResponse response = new HttpResponse();
-        Session session = new Session("sessionKey", new UserSessionInfo(user.getId(), user.getAccount(), user.getEmail()));
-        when(mockRequest.getSession()).thenReturn(session);
+        Session session = new Session(
+                "sessionKey",
+                new UserSessionInfo(user.getId(), user.getAccount(), user.getEmail()),
+                LocalDateTime.now().plusMinutes(10));
 
+        when(mockRequest.getSession()).thenReturn(session);
         userController.doGet(mockRequest, response);
         UserDTO modelUser = (UserDTO) response.getModelAndView().getModelValue(ModelName.USERINFO.getName());
 

--- a/src/test/java/com/youlpring/jws/controller/login/LogoutControllerTest.java
+++ b/src/test/java/com/youlpring/jws/controller/login/LogoutControllerTest.java
@@ -15,7 +15,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-@DisplayName("[unit] LogoutController 테스트")
+@DisplayName("[Unit] LogoutController 테스트")
 class LogoutControllerTest {
 
     private final static LogoutController logoutController = LogoutController.INSTANCE;

--- a/src/test/java/com/youlpring/jws/controller/login/SessionReloadControllerTest.java
+++ b/src/test/java/com/youlpring/jws/controller/login/SessionReloadControllerTest.java
@@ -1,0 +1,38 @@
+package com.youlpring.jws.controller.login;
+
+import com.youlpring.Fixture.jws.user.UserFixture;
+import com.youlpring.tomcat.apache.coyote.http11.context.CookieName;
+import com.youlpring.tomcat.apache.coyote.http11.context.Session;
+import com.youlpring.tomcat.apache.coyote.http11.context.SessionManager;
+import com.youlpring.tomcat.apache.coyote.http11.context.UserSessionInfo;
+import com.youlpring.tomcat.apache.coyote.http11.request.HttpRequest;
+import com.youlpring.tomcat.apache.coyote.http11.response.HttpResponse;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@DisplayName("[Unit] SessionReloadController 테스트")
+class SessionReloadControllerTest {
+
+    private final static SessionReloadController sessionReloadController = SessionReloadController.INSTANCE;
+
+    private final static SessionManager sessionManager = SessionManager.INSTANCE;
+
+    @Test
+    @DisplayName("세션 리로드에 성공한다.")
+    void sessionReloadSuccess() {
+        HttpRequest mockRequest = Mockito.mock(HttpRequest.class);
+        HttpResponse response = new HttpResponse();
+        Session oldSession = sessionManager.createSession(new UserSessionInfo(1L, UserFixture.ACCOUNT, UserFixture.USER.getEmail()));
+        sessionManager.add(oldSession);
+
+        Mockito.when(mockRequest.getSession()).thenReturn(oldSession);
+        sessionReloadController.doGet(mockRequest, response);
+
+        assertNull(sessionManager.findSession(oldSession.getSessionKey()));
+        assertNotEquals(oldSession.getSessionKey(), response.getCookie(CookieName.JSESSIONID.name()).getValue());
+        assertNotNull(sessionManager.findSession(response.getCookie(CookieName.JSESSIONID.name()).getValue()));
+    }
+}

--- a/src/test/java/com/youlpring/tomcat/apache/catalina/startup/TomcatTest.java
+++ b/src/test/java/com/youlpring/tomcat/apache/catalina/startup/TomcatTest.java
@@ -1,5 +1,6 @@
 package com.youlpring.tomcat.apache.catalina.startup;
 
+import com.youlpring.common.core.DefaultInitializer;
 import com.youlpring.tomcat.apache.catalina.connector.Connector;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -16,7 +17,8 @@ class TomcatTest {
     void TomcatSuccess() {
         Connector connector = mock(Connector.class);
         Tomcat tomcat = new Tomcat();
-        tomcat.start(connector);
+        DefaultInitializer defaultInitializer = new DefaultInitializer();
+        tomcat.start(connector, defaultInitializer);
 
         verify(connector, Mockito.times(1)).start();
         verify(connector, Mockito.times(1)).stop();

--- a/src/test/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionGarbageCollectorTest.java
+++ b/src/test/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionGarbageCollectorTest.java
@@ -13,7 +13,7 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 @DisplayName("[Unit] SessionGarbageCollector 테스트")
 class SessionGarbageCollectorTest {
 
-    SessionManager sessionManager = SessionManager.INSTANCE;
+    private final SessionManager sessionManager = SessionManager.INSTANCE;
 
     @Test
     @DisplayName("세션스토리지에 만료된 세션을 찾아 삭제에 성공한다.")

--- a/src/test/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionGarbageCollectorTest.java
+++ b/src/test/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionGarbageCollectorTest.java
@@ -10,7 +10,7 @@ import java.util.concurrent.TimeUnit;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
-@DisplayName("[Unit] SessionManager 테스트")
+@DisplayName("[Unit] SessionGarbageCollector 테스트")
 class SessionGarbageCollectorTest {
 
     SessionManager sessionManager = SessionManager.INSTANCE;

--- a/src/test/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionGarbageCollectorTest.java
+++ b/src/test/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionGarbageCollectorTest.java
@@ -1,0 +1,33 @@
+package com.youlpring.tomcat.apache.coyote.http11.context;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+@DisplayName("[Unit] SessionManager 테스트")
+class SessionGarbageCollectorTest {
+
+    SessionManager sessionManager = SessionManager.INSTANCE;
+
+    @Test
+    @DisplayName("세션스토리지에 만료된 세션을 찾아 삭제에 성공한다.")
+    void checkInvalidSessionSuccess() throws InterruptedException {
+        SessionGarbageCollector sessionGarbageCollector = new SessionGarbageCollector(0, 100, TimeUnit.MILLISECONDS);
+        Session session = new Session("key", Mockito.mock(UserSessionInfo.class), LocalDateTime.now().minusMinutes(1));
+        sessionManager.add(session);
+
+        Session findSession = sessionManager.findSession(session.getSessionKey());
+        assertEquals(session, findSession);
+
+        sessionGarbageCollector.processExpiredSessions();
+        Thread.sleep(1000);
+
+        assertNull(sessionManager.findSession(session.getSessionKey()));
+    }
+}

--- a/src/test/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionManagerTest.java
+++ b/src/test/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionManagerTest.java
@@ -4,6 +4,7 @@ import com.youlpring.tomcat.apache.coyote.http11.request.HttpRequest;
 import com.youlpring.tomcat.apache.coyote.http11.response.HttpResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 
@@ -90,13 +91,9 @@ class SessionManagerTest {
     @DisplayName("세션이 만료시간을 경과하였다면 세션 삭제에 성공한다.")
     void isTimeOverDeleteSuccess() {
         UserSessionInfo mockUserSessionInfo = mock(UserSessionInfo.class);
-        Session session = sessionManager.createSession(mockUserSessionInfo);
+        Session session = new Session("key", Mockito.mock(UserSessionInfo.class), LocalDateTime.now().minusMinutes(1));
         sessionManager.add(session);
-        Session mockSession = mock(Session.class);
-        when(mockSession.getSessionKey()).thenReturn(session.getSessionKey());
-        when(mockSession.getMaxEffectiveTime()).thenReturn(LocalDateTime.now().minusMinutes(1));
-
-        assertTrue(sessionManager.isTimeOver(mockSession));
+        assertTrue(sessionManager.isTimeOver(session));
         assertNull(sessionManager.findSession(session.getSessionKey()));
     }
 }

--- a/src/test/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionManagerTest.java
+++ b/src/test/java/com/youlpring/tomcat/apache/coyote/http11/context/SessionManagerTest.java
@@ -4,10 +4,10 @@ import com.youlpring.tomcat.apache.coyote.http11.request.HttpRequest;
 import com.youlpring.tomcat.apache.coyote.http11.response.HttpResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.time.LocalDateTime;
 
+import static com.youlpring.Fixture.tomcat.coyote.http11.UserSessionInfoFixture.USER_SESSION_INFO;
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
@@ -19,9 +19,7 @@ class SessionManagerTest {
     @Test
     @DisplayName("세션을 생성하는데 성공한다.")
     void createSessionSuccess() {
-        UserSessionInfo mockUserSessionInfo = mock(UserSessionInfo.class);
-
-        Session session = sessionManager.createSession(mockUserSessionInfo);
+        Session session = sessionManager.createSession(USER_SESSION_INFO);
 
         assertDoesNotThrow(() -> Long.parseLong(session.getSessionKey().substring(0, 8)));
         assertEquals(32, session.getSessionKey().length());
@@ -30,8 +28,7 @@ class SessionManagerTest {
     @Test
     @DisplayName("세선 저장에 성공한다.")
     void addSuccess() {
-        UserSessionInfo mockUserSessionInfo = mock(UserSessionInfo.class);
-        Session session = sessionManager.createSession(mockUserSessionInfo);
+        Session session = sessionManager.createSession(USER_SESSION_INFO);
 
         sessionManager.add(session);
 
@@ -51,8 +48,7 @@ class SessionManagerTest {
     @Test
     @DisplayName("세션 삭제에 성공한다.")
     void removeSuccess() {
-        UserSessionInfo mockUserSessionInfo = mock(UserSessionInfo.class);
-        Session session = sessionManager.createSession(mockUserSessionInfo);
+        Session session = sessionManager.createSession(USER_SESSION_INFO);
         sessionManager.add(session);
 
         sessionManager.remove(session);
@@ -63,8 +59,7 @@ class SessionManagerTest {
     @Test
     @DisplayName("세션을 삭제할때 HTTP 객체도 삭제를 반영하는데 성공한다.")
     void deleteSuccess() {
-        UserSessionInfo mockUserSessionInfo = mock(UserSessionInfo.class);
-        Session session = sessionManager.createSession(mockUserSessionInfo);
+        Session session = sessionManager.createSession(USER_SESSION_INFO);
         sessionManager.add(session);
         HttpRequest mockHttpRequest = mock(HttpRequest.class);
         HttpResponse response = new HttpResponse();
@@ -80,8 +75,7 @@ class SessionManagerTest {
     @Test
     @DisplayName("세션이 만료시간을 경과하지 않았다면 성공한다.")
     void isTimeOverSuccess() {
-        UserSessionInfo mockUserSessionInfo = mock(UserSessionInfo.class);
-        Session session = sessionManager.createSession(mockUserSessionInfo);
+        Session session = sessionManager.createSession(USER_SESSION_INFO);
         sessionManager.add(session);
 
         assertFalse(sessionManager.isTimeOver(session));
@@ -90,8 +84,7 @@ class SessionManagerTest {
     @Test
     @DisplayName("세션이 만료시간을 경과하였다면 세션 삭제에 성공한다.")
     void isTimeOverDeleteSuccess() {
-        UserSessionInfo mockUserSessionInfo = mock(UserSessionInfo.class);
-        Session session = new Session("key", Mockito.mock(UserSessionInfo.class), LocalDateTime.now().minusMinutes(1));
+        Session session = new Session("key", USER_SESSION_INFO, LocalDateTime.now().minusMinutes(1));
         sessionManager.add(session);
         assertTrue(sessionManager.isTimeOver(session));
         assertNull(sessionManager.findSession(session.getSessionKey()));

--- a/src/test/java/com/youlpring/tomcat/apache/coyote/http11/request/HttpRequestTest.java
+++ b/src/test/java/com/youlpring/tomcat/apache/coyote/http11/request/HttpRequestTest.java
@@ -17,6 +17,7 @@ import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.Socket;
+import java.time.LocalDateTime;
 
 import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.mock;
@@ -72,7 +73,7 @@ class HttpRequestTest {
     void initSessionSuccess() throws IOException {
         HttpRequest request = saveHttpRequest(RequestFixture.requestAll());
         SessionManager sessionManager = SessionManager.INSTANCE;
-        sessionManager.add(new Session(RequestFixture.JSSESIONID_VALUE, mock(UserSessionInfo.class)));
+        sessionManager.add(new Session(RequestFixture.JSSESIONID_VALUE, mock(UserSessionInfo.class), LocalDateTime.now().plusMinutes(10)));
 
         request.initSession();
 


### PR DESCRIPTION
안녕하세요.😀 

<br/>

지난 PR에서는 세션 로그인을 구현하였었는데요.
- #6 

<br/>


#### 이번에는 해당 세션스토리지의 몇가지 사항들을 보완하였습니다.
  - #8 
    - 세션스토리지에 있는 유효시간이 지난 세션들을 삭제하는 배치를 생성한다.
    - 세션 초기화 버튼을 만들어 세션 유지시간을 초기화 할 수 있도록 한다. (쿠키 탈취 공격 방지)

<br/>

#### 잘 부탁드립니다! 😊
______

📋 테스트 결과도 미리 볼 수 있으시도록 함께 첨부하여 드립니다. 

[<img src="https://github.com/beatmeJY/Youlpring/assets/54700818/8ee68d19-b4f6-41ed-a37e-729ad54b8870"  width="350" height="550"/>]

